### PR TITLE
Fix: TotalSupply is zero in FeeTracker

### DIFF
--- a/contracts/FeeTracker.sol
+++ b/contracts/FeeTracker.sol
@@ -137,6 +137,6 @@ contract FeeTracker is IFeeTracker, RewardTracker {
         totalInactivePoints = totalInactivePoints + _inactivePoint - inactivePoints[_account];
         inactivePoints[_account] = _inactivePoint;
 
-        require(totalSupply > totalInactivePoints, "FeeTracker: Something quite wrong");
+        require(totalSupply >= totalInactivePoints, "FeeTracker: Something quite wrong");
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gammaswap/v1-staking",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Staking contracts for GammaSwapV1 protocol",
   "scripts": {
     "hardhat": "hardhat",


### PR DESCRIPTION
check totalSupply = totalInactivePoints for when they're both zero (withdrew everything)